### PR TITLE
[RHOAIENG-9742]: Remove About Modal Content Override

### DIFF
--- a/frontend/src/app/AboutDialog.scss
+++ b/frontend/src/app/AboutDialog.scss
@@ -1,9 +1,0 @@
-// TODO: Remove when PF provides a fix for https://github.com/patternfly/patternfly/issues/6871
-// Override for about box height, reduce to fit the content instead of a fixed height
-// Override to use the full width of the dialog rather than wrapping early
-.odh-about-dialog {
-  height: fit-content;
-  .pf-v6-c-about-modal-box__content {
-    grid-column-end: -1;
-  }
-}

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -6,8 +6,6 @@ import { useAppContext } from '~/app/AppContext';
 import useFetchDsciStatus from '~/concepts/areas/useFetchDsciStatus';
 import { useWatchOperatorSubscriptionStatus } from '~/utilities/useWatchOperatorSubscriptionStatus';
 
-import './AboutDialog.scss';
-
 const RhoaiAboutText = `Red Hat® OpenShift® AI (formerly Red Hat OpenShift Data Science) is a flexible, scalable MLOps platform for data scientists and developers of artificial intelligence and machine learning (AI/ML) applications. Built using open source technologies, OpenShift AI supports the full lifecycle of AI/ML experiments and models, on premise and in the public cloud.`;
 const RhoaiDefaultReleaseName = `OpenShift AI`;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-9742

See also https://github.com/opendatahub-io/odh-dashboard/pull/3038#discussion_r1837188495

Wrapping behavior is now correct on long labels and text in About Modal. 

Verified as resolved in v6:
<img width="1193" alt="Screenshot 2024-11-26 at 5 05 19 PM" src="https://github.com/user-attachments/assets/9098c426-5b84-407b-a330-5b31099b05ab">

