### PR TITLE
remove findKebabActionByMenuId and fix up dropdown selectors

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/clusterStorage.ts
@@ -61,10 +61,6 @@ class ClusterStorageModal extends Modal {
       .findByRole('button', { name: 'Typeahead menu toggle', hidden: true });
   }
 
-  findWorkbenchConnectionOption(name: string) {
-    return cy.get('#connected-notebook-select').findByText(name);
-  }
-
   findMountField() {
     return this.find().findByTestId('mount-path-folder-value');
   }
@@ -90,12 +86,12 @@ class ClusterStorageModal extends Modal {
   }
 
   private findPVSizeSelectButton() {
-    return cy.findByTestId('value-unit-select');
+    return this.find().findByTestId('value-unit-select');
   }
 
   selectPVSize(name: string) {
-    this.findPVSizeSelectButton().click();
-    cy.findByRole('menuitem', { name, hidden: true }).click();
+    this.findPVSizeSelectButton().findDropdownItem(name).click();
+    return this;
   }
 
   shouldHavePVSizeSelectValue(name: string) {

--- a/frontend/src/__tests__/cypress/cypress/pages/components/table.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/table.ts
@@ -20,10 +20,6 @@ export class TableRow extends Contextual<HTMLTableRowElement> {
     return this.find().findKebabAction(name);
   }
 
-  findKebabActionByMenuId(name: string, menuId: string): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().findKebabActionByMenuId(name, menuId);
-  }
-
   findKebab(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().findKebab();
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
@@ -53,26 +53,19 @@ class PipelineRunFilterBar extends PipelineFilterBar {
 
   selectStatusByName(name: string) {
     this.findStatusSelect().findSelectOption(name).click();
+    return this;
   }
 
-  selectPipelineVersionByName(name: string): void {
-    this.findPipelineVersionSelect()
-      .click()
-      .parents()
-      .findByTestId('pipeline-version-selector-table-list')
-      .find('td')
-      .contains(name)
-      .click();
+  selectPipelineVersionByName(name: string) {
+    this.findPipelineVersionSelect().click();
+    cy.findByTestId('pipeline-version-selector-table-list').find('td').contains(name).click();
+    return this;
   }
 
-  selectExperimentByName(name: string): Cypress.Chainable<JQuery<HTMLTableCellElement>> {
-    return this.findExperimentSelect()
-      .click()
-      .document() // This will need to be updated if the appendTo for PatternFly menus is changed
-      .findByTestId('experiment-selector-table-list')
-      .find('td')
-      .contains(name)
-      .click();
+  selectExperimentByName(name: string) {
+    this.findExperimentSelect().click();
+    cy.findByTestId('experiment-selector-table-list').find('td').contains(name).click();
+    return this;
   }
 
   mockExperiments(experiments: ExperimentKF[], namespace: string) {

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -66,7 +66,7 @@ class ProjectRow extends TableRow {
   }
 
   findNotebookColumnExpander() {
-    return this.find().get('#expand-table-row-1-1');
+    return this.find().findByTestId('notebook-column-expand').find('button');
   }
 
   findNotebookTable() {

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -199,7 +199,7 @@ class AttachExistingStorageModal extends Modal {
     cy.findByTestId('persistent-storage-group')
       .findByPlaceholderText('Select a persistent storage')
       .click();
-    cy.findByTestId('persistent-storage-group').contains('button.pf-v5-c-menu__item', name).click();
+    cy.findByTestId('persistent-storage-group').contains('button.pf-v6-c-menu__item', name).click();
   }
 
   findStandardPathInput() {
@@ -288,13 +288,6 @@ class CreateSpawnerPage {
     return cy.findByTestId('existing-storage-button');
   }
 
-  selectExistingPersistentStorage(name: string) {
-    cy.findByTestId('persistent-storage-group')
-      .findByRole('button', { name: 'Typeahead menu toggle' })
-      .click();
-    cy.get('[id="dashboard-page-main"]').contains('button.pf-v6-c-menu__item', name).click();
-  }
-
   selectPVSize(name: string) {
     this.findPVSizeSelectButton().click();
     cy.findByRole('menuitem', { name }).click();
@@ -364,8 +357,8 @@ class CreateSpawnerPage {
   selectExistingDataConnection(name: string) {
     cy.findByTestId('data-connection-group')
       .findByRole('button', { name: 'Typeahead menu toggle' })
+      .findSelectOption(name)
       .click();
-    cy.get('#select-connection').findByRole('option', { name }).click();
   }
 
   findAwsNameInput() {

--- a/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
@@ -43,18 +43,6 @@ declare global {
       ) => Cypress.Chainable<JQuery>;
 
       /**
-       * Finds a patternfly kebab toggle button, opens the menu, and finds the action.
-       *
-       * @param name the name of the action in the kebeb menu
-       * @param isDropdownToggle - True to indicate that it is a dropdown toggle instead of table kebab actions
-       */
-      findKebabActionByMenuId: (
-        name: string | RegExp,
-        menuId: string,
-        isDropdownToggle?: boolean,
-      ) => Cypress.Chainable<JQuery>;
-
-      /**
        * Finds a patternfly dropdown item by first opening the dropdown if not already opened.
        *
        * @param name the name of the item
@@ -216,24 +204,7 @@ Cypress.Commands.add(
         if ($el.attr('aria-expanded') === 'false') {
           cy.wrap($el).click();
         }
-        return cy.findByRole('menuitem', { name });
-      });
-  },
-);
-
-Cypress.Commands.add(
-  'findKebabActionByMenuId',
-  { prevSubject: 'element' },
-  (subject, name, menuId, isDropdownToggle) => {
-    Cypress.log({ displayName: 'findKebabByMenuId', message: name });
-    return cy
-      .wrap(subject)
-      .findKebab(isDropdownToggle)
-      .then(($el) => {
-        if ($el.attr('aria-expanded') === 'false') {
-          cy.wrap($el).click();
-        }
-        return cy.get(`#${menuId}`).findByRole('menuitem', { name });
+        return cy.get('[data-ouia-component-type="PF6/Dropdown"]').findByRole('menuitem', { name });
       });
   },
 );
@@ -244,7 +215,7 @@ Cypress.Commands.add('findDropdownItem', { prevSubject: 'element' }, (subject, n
     if ($el.attr('aria-expanded') === 'false') {
       cy.wrap($el).click();
     }
-    return cy.wrap($el).parent().findByRole('menuitem', { name });
+    return cy.get('[data-ouia-component-type="PF6/Dropdown"]').findByRole('menuitem', { name });
   });
 });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/acceleratorProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/acceleratorProfiles.cy.ts
@@ -122,10 +122,7 @@ describe('Accelerator Profile', () => {
       { success: true },
     ).as('delete');
     acceleratorProfile.visit();
-    acceleratorProfile
-      .getRow('TensorRT')
-      .findKebabActionByMenuId('Delete', 'accelerator-profile-actions')
-      .click();
+    acceleratorProfile.getRow('TensorRT').findKebabAction('Delete').click();
     deleteModal.findSubmitButton().should('be.disabled');
     deleteModal.findInput().fill('TensorRT');
     deleteModal.findSubmitButton().should('be.enabled').click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts
@@ -124,29 +124,26 @@ describe('Manage Accelerator Profile', () => {
 
     // test edit toleration
     let tableRow = createAcceleratorProfile.getRow('test-key');
-    tableRow.findKebabActionByMenuId('Edit', 'toleration-actions').click();
+    tableRow.findKebabAction('Edit').click();
     editTolerationModal.findTolerationKeyInput().fill('test-update');
     editTolerationModal.findCancelButton().click();
     createAcceleratorProfile.getRow('test-key');
-    tableRow.findKebabActionByMenuId('Edit', 'toleration-actions').click();
+    tableRow.findKebabAction('Edit').click();
     editTolerationModal.findTolerationKeyInput().fill('updated-test');
     editTolerationModal.findTolerationSubmitButton().click();
     tableRow = createAcceleratorProfile.getRow('updated-test');
     tableRow.shouldHaveOperator('Equal');
 
     // test cancel clears fields
-    tableRow.findKebabActionByMenuId('Edit', 'toleration-actions').click();
+    tableRow.findKebabAction('Edit').click();
     editTolerationModal.findCancelButton().click();
     createAcceleratorProfile.findTolerationsButton().click();
     createTolerationModal.findTolerationSubmitButton().should('be.disabled');
     createTolerationModal.findCancelButton().click();
 
     // test delete
-    tableRow.findKebabActionByMenuId('Delete', 'toleration-actions').click();
-    createAcceleratorProfile
-      .getRow('toleration-key')
-      .findKebabActionByMenuId('Delete', 'toleration-actions')
-      .click();
+    tableRow.findKebabAction('Delete').click();
+    createAcceleratorProfile.getRow('toleration-key').findKebabAction('Delete').click();
     createAcceleratorProfile.shouldHaveModalEmptyState();
     cy.interceptOdh('POST /api/accelerator-profiles', { success: true }).as('createAccelerator');
     createAcceleratorProfile.findSubmitButton().click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/administration.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/administration.cy.ts
@@ -137,7 +137,7 @@ describe('Administration Tab', () => {
     userRow.shouldHavePrivilege('User');
     userRow.shouldHaveLastActivity('Just now');
     userRow.findServerStatusButton().should('have.text', 'View server');
-    userRow.findKebabActionByMenuId('Stop server', 'notebook-actions').click();
+    userRow.findKebabAction('Stop server').click();
 
     stopNotebookModal.findStopNotebookServerButton().should('be.enabled');
     stopNotebookModal.findStopNotebookServerButton().click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
@@ -95,7 +95,7 @@ describe('Connection types', () => {
     row2.shouldBeDisabled();
     row2.findConnectionTypeCompatibility().should('have.text', 'S3 compatible object storage');
 
-    row2.findKebabActionByMenuId('Preview', 'connection-type-actions').click();
+    row2.findKebabAction('Preview').click();
     connectionTypePreviewModal.shouldBeOpen();
     connectionTypePreviewModal.findCloseButton().click();
     connectionTypePreviewModal.shouldBeOpen(false);
@@ -124,10 +124,7 @@ describe('Connection types', () => {
       }),
     ]);
 
-    connectionTypesPage
-      .getConnectionTypeRow('Test display name')
-      .findKebabActionByMenuId('Delete', 'connection-type-actions')
-      .click();
+    connectionTypesPage.getConnectionTypeRow('Test display name').findKebabAction('Delete').click();
     deleteModal.findSubmitButton().should('be.disabled');
     deleteModal.findInput().fill('Test display name');
     deleteModal.findSubmitButton().should('be.enabled').click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -291,7 +291,7 @@ describe('edit', () => {
 
     createConnectionTypePage
       .getFieldsTableRow(4)
-      .findKebabActionByMenuId('Move to section heading', 'connection-type-field-actions')
+      .findKebabAction('Move to section heading')
       .click();
     // move to default which is the first section
     cy.findByTestId('section-heading-select').should('be.disabled');
@@ -306,7 +306,7 @@ describe('edit', () => {
 
     createConnectionTypePage
       .getFieldsTableRow(0)
-      .findKebabActionByMenuId('Move to section heading', 'connection-type-field-actions')
+      .findKebabAction('Move to section heading')
       .click();
     cy.findByTestId('section-heading-select').click();
     cy.findByTestId('section-heading-select').findSelectOption('header2').click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
@@ -209,11 +209,7 @@ describe('Custom serving runtimes', () => {
       'duplicateTemplate',
     );
 
-    servingRuntimes
-      .getRowById('template-1')
-      .find()
-      .findKebabActionByMenuId('Duplicate', 'custom-serving-runtime-actions')
-      .click();
+    servingRuntimes.getRowById('template-1').find().findKebabAction('Duplicate').click();
     servingRuntimes.findAppTitle().should('have.text', 'Duplicate serving runtime');
     cy.url().should('include', '/addServingRuntime');
 
@@ -280,11 +276,7 @@ describe('Custom serving runtimes', () => {
       mockServingRuntimeTemplateK8sResource({}),
     ).as('editTemplate');
 
-    servingRuntimes
-      .getRowById('template-1')
-      .find()
-      .findKebabActionByMenuId('Edit', 'custom-serving-runtime-actions')
-      .click();
+    servingRuntimes.getRowById('template-1').find().findKebabAction('Edit').click();
     servingRuntimes.findAppTitle().should('contain', 'Edit Multi Platform');
     cy.url().should('include', '/editServingRuntime/template-1');
     servingRuntimes.findSubmitButton().should('be.disabled');
@@ -331,11 +323,7 @@ describe('Custom serving runtimes', () => {
       mockServingRuntimeTemplateK8sResource({}),
     ).as('deleteServingRuntime');
 
-    servingRuntimes
-      .getRowById('template-1')
-      .find()
-      .findKebabActionByMenuId('Delete', 'custom-serving-runtime-actions')
-      .click();
+    servingRuntimes.getRowById('template-1').find().findKebabAction('Delete').click();
     deleteModal.findSubmitButton().should('be.disabled');
 
     // test delete form is enabled after filling out required fields

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionArchive.cy.ts
@@ -239,9 +239,7 @@ describe('Restoring archive version', () => {
     modelVersionArchive.visit();
 
     const archiveVersionRow = modelVersionArchive.getRow('model version 2');
-    archiveVersionRow
-      .findKebabActionByMenuId('Restore model version', 'model-version-actions')
-      .click();
+    archiveVersionRow.findKebabAction('Restore model version').click();
 
     restoreVersionModal.findRestoreButton().click();
 
@@ -297,9 +295,7 @@ describe('Archiving version', () => {
     modelVersionArchive.visitModelVersionList();
 
     const modelVersionRow = modelRegistry.getModelVersionRow('model version 3');
-    modelVersionRow
-      .findKebabActionByMenuId('Archive model version', 'model-version-actions')
-      .click();
+    modelVersionRow.findKebabAction('Archive model version').click();
     archiveVersionModal.findArchiveButton().should('be.disabled');
     archiveVersionModal.findModalTextInput().fill('model version 3');
     archiveVersionModal.findArchiveButton().should('be.enabled').click();
@@ -342,9 +338,7 @@ describe('Archiving version', () => {
     modelVersionArchive.visitModelVersionList();
 
     const modelVersionRow = modelRegistry.getModelVersionRow('model version 3');
-    modelVersionRow
-      .findKebabActionByMenuId('Archive model version', 'model-version-actions')
-      .should('have.attr', 'aria-disabled');
+    modelVersionRow.findKebabAction('Archive model version').should('have.attr', 'aria-disabled');
   });
 
   it('Cannot archive model that has versions with a deployment', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDeploy.cy.ts
@@ -184,7 +184,7 @@ describe('Deploy model version', () => {
     initIntercepts({ kServeInstalled: false, modelMeshInstalled: false });
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
-    modelVersionRow.findKebabActionByMenuId('Deploy', 'model-version-actions').click();
+    modelVersionRow.findKebabAction('Deploy').click();
     modelVersionDeployModal.selectProjectByName('Model mesh project');
     cy.findByText('Multi-model platform is not installed').should('exist');
     modelVersionDeployModal.selectProjectByName('KServe project');
@@ -195,7 +195,7 @@ describe('Deploy model version', () => {
     initIntercepts({});
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
-    modelVersionRow.findKebabActionByMenuId('Deploy', 'model-version-actions').click();
+    modelVersionRow.findKebabAction('Deploy').click();
     modelVersionDeployModal.selectProjectByName('Test project');
     cy.findByText('Cannot deploy the model until you select a model serving platform').should(
       'exist',
@@ -206,7 +206,7 @@ describe('Deploy model version', () => {
     initIntercepts({});
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
-    modelVersionRow.findKebabActionByMenuId('Deploy', 'model-version-actions').click();
+    modelVersionRow.findKebabAction('Deploy').click();
     cy.interceptK8sList(ServingRuntimeModel, mockK8sResourceList([]));
     modelVersionDeployModal.selectProjectByName('Model mesh project');
     cy.findByText('Cannot deploy the model until you configure a model server').should('exist');
@@ -229,7 +229,7 @@ describe('Deploy model version', () => {
     );
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
-    modelVersionRow.findKebabActionByMenuId('Deploy', 'model-version-actions').click();
+    modelVersionRow.findKebabAction('Deploy').click();
     modelVersionDeployModal.selectProjectByName('KServe project');
 
     // Validate name input field
@@ -284,7 +284,7 @@ describe('Deploy model version', () => {
 
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
-    modelVersionRow.findKebabActionByMenuId('Deploy', 'model-version-actions').click();
+    modelVersionRow.findKebabAction('Deploy').click();
     modelVersionDeployModal.selectProjectByName('KServe project');
 
     // Validate data connection section
@@ -325,7 +325,7 @@ describe('Deploy model version', () => {
 
     cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
     const modelVersionRow = modelRegistry.getModelVersionRow('test model version');
-    modelVersionRow.findKebabActionByMenuId('Deploy', 'model-version-actions').click();
+    modelVersionRow.findKebabAction('Deploy').click();
     modelVersionDeployModal.selectProjectByName('KServe project');
 
     // Validate data connection section

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersionDetails.cy.ts
@@ -261,12 +261,12 @@ describe('Model version details', () => {
       modelVersionDetails.findExpandControlButton().should('have.text', 'Show 2 more properties');
       modelVersionDetails.findExpandControlButton().click();
       const propertyRow = modelVersionDetails.getRow('a6');
-      propertyRow.find().findKebabActionByMenuId('Edit', 'model-properties-actions').click();
+      propertyRow.find().findKebabAction('Edit').click();
       modelVersionDetails.findKeyEditInput('a6').clear().type('edit_key');
       modelVersionDetails.findValueEditInput('v1').clear().type('edit_value');
 
       modelVersionDetails.findCancelButton().click();
-      propertyRow.find().findKebabActionByMenuId('Edit', 'model-properties-actions').click();
+      propertyRow.find().findKebabAction('Edit').click();
       modelVersionDetails.findKeyEditInput('a6').clear().type('edit_key');
       modelVersionDetails.findValueEditInput('v1').clear().type('edit_value');
       modelVersionDetails.findSaveButton().click();
@@ -300,7 +300,7 @@ describe('Model version details', () => {
       modelVersionDetails.findExpandControlButton().click();
       const propertyRow = modelVersionDetails.getRow('a6');
       modelVersionDetails.findPropertiesTableRows().should('have.length', 7);
-      propertyRow.find().findKebabActionByMenuId('Delete', 'model-properties-actions').click();
+      propertyRow.find().findKebabAction('Delete').click();
       cy.wait('@UpdatePropertyRow').then((interception) => {
         expect(interception.request.body).to.eql({
           customProperties: {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registeredModelArchive.cy.ts
@@ -269,7 +269,7 @@ it('Opens the detail page when we select "View Details" from action menu', () =>
   initIntercepts({});
   registeredModelArchive.visit();
   const archiveModelRow = registeredModelArchive.getRow('model 2');
-  archiveModelRow.findKebabActionByMenuId('View details', 'registered-modal-actions').click();
+  archiveModelRow.findKebabAction('View details').click();
   cy.location('pathname').should(
     'be.equals',
     '/modelRegistry/modelregistry-sample/registeredModels/archive/2/details',
@@ -294,7 +294,7 @@ describe('Restoring archive model', () => {
     registeredModelArchive.visit();
 
     const archiveModelRow = registeredModelArchive.getRow('model 2');
-    archiveModelRow.findKebabActionByMenuId('Restore model', 'registered-modal-actions').click();
+    archiveModelRow.findKebabAction('Restore model').click();
 
     restoreModelModal.findRestoreButton().click();
 
@@ -350,7 +350,7 @@ describe('Archiving model', () => {
     registeredModelArchive.visitModelList();
 
     const modelRow = modelRegistry.getRow('model 3');
-    modelRow.findKebabActionByMenuId('Archive model', 'registered-modal-actions').click();
+    modelRow.findKebabAction('Archive model').click();
     archiveModelModal.findArchiveButton().should('be.disabled');
     archiveModelModal.findModalTextInput().fill('model 3');
     archiveModelModal.findArchiveButton().should('be.enabled').click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
@@ -215,10 +215,7 @@ describe('MR Permissions', () => {
 
       modelRegistryPermissions.visit('example-mr');
 
-      userTable
-        .getTableRow('example-mr-user')
-        .findKebabActionByMenuId('Edit', 'role-bindings-permissions-actions')
-        .click();
+      userTable.getTableRow('example-mr-user').findKebabAction('Edit').click();
       userTable.findEditInput('example-mr-user').clear().type('edited-user');
       userTable.findEditSaveButton('edited-user').click();
 
@@ -256,10 +253,7 @@ describe('MR Permissions', () => {
 
       modelRegistryPermissions.visit('example-mr');
 
-      userTable
-        .getTableRow('example-mr-user')
-        .findKebabActionByMenuId('Delete', 'role-bindings-permissions-actions')
-        .click();
+      userTable.getTableRow('example-mr-user').findKebabAction('Delete').click();
 
       cy.wait('@deleteUser');
     });
@@ -350,10 +344,7 @@ describe('MR Permissions', () => {
 
       modelRegistryPermissions.visit('example-mr');
 
-      groupTable
-        .getTableRow('example-mr-users-2')
-        .findKebabActionByMenuId('Edit', 'role-bindings-permissions-actions')
-        .click();
+      groupTable.getTableRow('example-mr-users-2').findKebabAction('Edit').click();
       groupTable.findNameSelect().clear().type('example-mr-group-opti');
       cy.findByText('example-mr-group-option').click();
       groupTable.findEditSaveButton('example-mr-group-option').click();
@@ -397,10 +388,7 @@ describe('MR Permissions', () => {
       ).as('deleteGroup');
 
       modelRegistryPermissions.visit('example-mr');
-      groupTable
-        .getTableRow('example-mr-users-2')
-        .findKebabActionByMenuId('Delete', 'role-bindings-permissions-actions')
-        .click();
+      groupTable.getTableRow('example-mr-users-2').findKebabAction('Delete').click();
 
       cy.wait('@deleteGroup');
     });
@@ -504,10 +492,7 @@ describe('MR Permissions', () => {
         mock200Status({}),
       ).as('deleteProject');
 
-      projectTable
-        .getTableRow('Test Project')
-        .findKebabActionByMenuId('Edit', 'role-bindings-permissions-actions')
-        .click();
+      projectTable.getTableRow('Test Project').findKebabAction('Edit').click();
       projectTable.findNameSelect().findSelectOption('Project').click();
       projectTable.findEditSaveButton('Project').click();
 
@@ -536,10 +521,7 @@ describe('MR Permissions', () => {
         { path: { name: 'test-name-view' } },
         mock200Status({}),
       ).as('deleteProject');
-      projectTable
-        .getTableRow('Test Project')
-        .findKebabActionByMenuId('Delete', 'role-bindings-permissions-actions')
-        .click();
+      projectTable.getTableRow('Test Project').findKebabAction('Delete').click();
       cy.wait('@deleteProject');
     });
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -182,7 +182,7 @@ describe('ViewDatabaseConfigModal', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings
       .findModelRegistryRow('test-registry-1')
-      .findKebabActionByMenuId('View database configuration', 'model-registry-actions')
+      .findKebabAction('View database configuration')
       .click();
     modelRegistrySettings
       .findDatabaseDetail(DatabaseDetailsTestId.HOST)
@@ -207,7 +207,7 @@ describe('ViewDatabaseConfigModal', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings
       .findModelRegistryRow('test-registry-2')
-      .findKebabActionByMenuId('View database configuration', 'model-registry-actions')
+      .findKebabAction('View database configuration')
       .click();
     cy.findByText('Error loading password').should('exist');
   });
@@ -241,7 +241,7 @@ describe('DeleteModelRegistryModal', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings
       .findModelRegistryRow('test-registry-1')
-      .findKebabActionByMenuId('Delete model registry', 'model-registry-actions')
+      .findKebabAction('Delete model registry')
       .click();
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -236,7 +236,7 @@ describe('Model Serving Global', () => {
     // user flow for deleting a project
     modelServingGlobal
       .getModelRow('Test Inference Service')
-      .findKebabActionByMenuId(/^Delete/, 'inference-table-actions')
+      .findKebabAction(/^Delete/)
       .click();
 
     // Test that can submit on valid form
@@ -270,10 +270,7 @@ describe('Model Serving Global', () => {
     modelServingGlobal.visit('test-project');
 
     // user flow for editing a project
-    modelServingGlobal
-      .getModelRow('Test Inference Service')
-      .findKebabActionByMenuId('Edit', 'inference-table-actions')
-      .click();
+    modelServingGlobal.getModelRow('Test Inference Service').findKebabAction('Edit').click();
 
     // test that you can not submit on empty
     inferenceServiceModalEdit.shouldBeOpen();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -46,13 +46,7 @@ describe('NIM Models Deployments', () => {
     cy.interceptK8sList(ServingRuntimeModel, mockK8sResourceList([mockNimServingRuntime()]));
 
     modelServingGlobal.visit('test-project');
-    modelServingGlobal
-      .getModelRow('Test Name')
-      .findKebabActionByMenuId('Edit', 'inference-table-actions')
-      .should('exist');
-    modelServingGlobal
-      .getModelRow('Test Name')
-      .findKebabActionByMenuId('Delete', 'inference-table-actions')
-      .should('exist');
+    modelServingGlobal.getModelRow('Test Name').findKebabAction('Edit').should('exist');
+    modelServingGlobal.getModelRow('Test Name').findKebabAction('Delete').should('exist');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/servingRuntimeList.cy.ts
@@ -528,10 +528,7 @@ describe('Serving Runtime List', () => {
         .getModelMeshRow('OVMS Model Serving')
         .findDeployedModelExpansionButton()
         .click();
-      modelServingSection
-        .getInferenceServiceRow('OVMS ONNX')
-        .findKebabActionByMenuId('Edit', 'inference-table-actions')
-        .click();
+      modelServingSection.getInferenceServiceRow('OVMS ONNX').findKebabAction('Edit').click();
       inferenceServiceModalEdit.shouldBeOpen();
       inferenceServiceModalEdit
         .findServingRuntimeSelect()
@@ -1036,11 +1033,7 @@ describe('Serving Runtime List', () => {
       projectDetails.visitSection('test-project', 'model-server');
 
       // click on the toggle button and open edit model server
-      modelServingSection
-        .getKServeRow('Llama Service')
-        .find()
-        .findKebabActionByMenuId('Edit', 'inference-table-actions')
-        .click();
+      modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
 
       kserveModalEdit.shouldBeOpen();
 
@@ -1222,10 +1215,7 @@ describe('Serving Runtime List', () => {
         mock200Status({}),
       ).as('deleteRoleBindings');
       projectDetails.visitSection('test-project', 'model-server');
-      modelServingSection
-        .getModelMeshRow('ovms')
-        .findKebabActionByMenuId('Delete model server', 'serving-runtime-actions')
-        .click();
+      modelServingSection.getModelMeshRow('ovms').findKebabAction('Delete model server').click();
       deleteModal.shouldBeOpen();
       deleteModal.findSubmitButton().should('be.disabled');
 
@@ -1463,7 +1453,7 @@ describe('Serving Runtime List', () => {
       modelServingSection
         .getModelMeshRow('ovms')
         .find()
-        .findKebabActionByMenuId('Edit model server', 'serving-runtime-actions')
+        .findKebabAction('Edit model server')
         .click();
 
       editServingRuntimeModal.shouldBeOpen();
@@ -2159,7 +2149,7 @@ describe('Serving Runtime List', () => {
         .should('contain.text', 'Small');
 
       // click on the toggle button and open edit model server
-      kserveRow.find().findKebabActionByMenuId('Edit', 'inference-table-actions').click();
+      kserveRow.find().findKebabAction('Edit').click();
 
       kserveModalEdit.shouldBeOpen();
 
@@ -2209,7 +2199,7 @@ describe('Serving Runtime List', () => {
         .should('contain.text', 'Small');
 
       // click on the toggle button and open edit model server
-      kserveRow.find().findKebabActionByMenuId('Edit', 'inference-table-actions').click();
+      kserveRow.find().findKebabAction('Edit').click();
 
       kserveModalEdit.shouldBeOpen();
 
@@ -2260,11 +2250,7 @@ describe('Serving Runtime List', () => {
         .should('contain.text', 'Custom');
 
       // click on the toggle button and open edit model server
-      modelServingSection
-        .getKServeRow('Llama Service')
-        .find()
-        .findKebabActionByMenuId('Edit', 'inference-table-actions')
-        .click();
+      modelServingSection.getKServeRow('Llama Service').find().findKebabAction('Edit').click();
 
       kserveModalEdit.shouldBeOpen();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/notebookImageSettings/notebookImageSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/notebookImageSettings/notebookImageSettings.cy.ts
@@ -242,11 +242,7 @@ describe('Notebook image settings', () => {
     notebookImageSettings.visit();
 
     // open edit form
-    notebookImageSettings
-      .getRow('Testing Custom Image')
-      .find()
-      .findKebabActionByMenuId('Edit', 'byon-image-actions')
-      .click();
+    notebookImageSettings.getRow('Testing Custom Image').find().findKebabAction('Edit').click();
 
     // test inputs have correct values
     updateNotebookImageModal.findImageLocationInput().should('have.value', 'test-image:latest');
@@ -293,11 +289,7 @@ describe('Notebook image settings', () => {
     notebookImageSettings.visit();
 
     // test delete form is disabled initially
-    notebookImageSettings
-      .getRow('Testing Custom Image')
-      .find()
-      .findKebabActionByMenuId('Delete', 'byon-image-actions')
-      .click();
+    notebookImageSettings.getRow('Testing Custom Image').find().findKebabAction('Delete').click();
 
     deleteModal.findSubmitButton().should('be.disabled');
 
@@ -355,11 +347,7 @@ describe('Notebook image settings', () => {
     importNotebookImageModal.findCloseButton().click();
 
     // edit error
-    notebookImageSettings
-      .getRow('Testing Custom Image')
-      .find()
-      .findKebabActionByMenuId('Edit', 'byon-image-actions')
-      .click();
+    notebookImageSettings.getRow('Testing Custom Image').find().findKebabAction('Edit').click();
     updateNotebookImageModal.findSubmitButton().click();
 
     cy.wait('@editError');
@@ -368,11 +356,7 @@ describe('Notebook image settings', () => {
     updateNotebookImageModal.findCloseButton().click();
 
     // delete error
-    notebookImageSettings
-      .getRow('Testing Custom Image')
-      .find()
-      .findKebabActionByMenuId('Delete', 'byon-image-actions')
-      .click();
+    notebookImageSettings.getRow('Testing Custom Image').find().findKebabAction('Delete').click();
     notebookImageDeleteModal.findInput().type('Testing Custom Image');
     notebookImageDeleteModal.findSubmitButton().click();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/experiments.cy.ts
@@ -139,7 +139,7 @@ describe('Experiments', () => {
       activeExperimentsTable.mockArchiveExperiment(experimentToArchive.experiment_id, projectName);
       activeExperimentsTable
         .getRowByName(experimentToArchive.display_name)
-        .findKebabActionByMenuId('Archive', 'experiment-actions')
+        .findKebabAction('Archive')
         .click();
 
       experimentsTabs.mockGetExperiments(projectName, [
@@ -202,7 +202,7 @@ describe('Experiments', () => {
       );
       archivedExperimentsTable
         .getRowByName(experimentToRestore.display_name)
-        .findKebabActionByMenuId('Restore', 'experiment-actions')
+        .findKebabAction('Restore')
         .click();
 
       experimentsTabs.mockGetExperiments(projectName, [

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineCreateRuns.cy.ts
@@ -222,10 +222,7 @@ describe('Pipeline create runs', () => {
       // Navigate to duplicate run page for a given active run
       cy.visitWithLogin(`/experiments/${projectName}/experiment-1/runs`);
       pipelineRunsGlobal.findActiveRunsTab().click();
-      activeRunsTable
-        .getRowByName(mockRun.display_name)
-        .findKebabActionByMenuId('Duplicate', 'pipeline-run-table-row-actions')
-        .click();
+      activeRunsTable.getRowByName(mockRun.display_name).findKebabAction('Duplicate').click();
       verifyRelativeURL(
         `/experiments/${projectName}/experiment-1/runs/duplicate/${mockRun.run_id}`,
       );
@@ -668,7 +665,7 @@ describe('Pipeline create runs', () => {
       pipelineRunsGlobal.findSchedulesTab().click();
       pipelineRecurringRunTable
         .getRowByName(mockRecurringRun.display_name)
-        .findKebabActionByMenuId('Duplicate', 'pipeline-recurring-run-actions')
+        .findKebabAction('Duplicate')
         .click();
       verifyRelativeURL(
         `/experiments/${projectName}/experiment-1/schedules/duplicate/${mockRecurringRun.recurring_run_id}`,
@@ -746,7 +743,7 @@ describe('Pipeline create runs', () => {
       pipelineRunsGlobal.findSchedulesTab().click();
       pipelineRecurringRunTable
         .getRowByName(mockRecurringRun.display_name)
-        .findKebabActionByMenuId('Duplicate', 'pipeline-recurring-run-actions')
+        .findKebabAction('Duplicate')
         .click();
       verifyRelativeURL(
         `/experiments/${projectName}/experiment-1/schedules/duplicate/${mockRecurringRun.recurring_run_id}`,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineDeleteRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineDeleteRuns.cy.ts
@@ -124,10 +124,7 @@ describe('Test deleting runs', () => {
 
   it('Test delete a single schedule', () => {
     pipelineRunsGlobal.findSchedulesTab().click();
-    pipelineRecurringRunTable
-      .getRowByName('test-pipeline')
-      .findKebabActionByMenuId('Delete', 'pipeline-recurring-run-actions')
-      .click();
+    pipelineRecurringRunTable.getRowByName('test-pipeline').findKebabAction('Delete').click();
 
     schedulesDeleteModal.shouldBeOpen();
     schedulesDeleteModal.findSubmitButton().should('be.disabled');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelineRuns.cy.ts
@@ -979,7 +979,7 @@ describe('Pipeline runs', () => {
           pipelineRunsGlobal.findSchedulesTab().click();
           pipelineRecurringRunTable
             .getRowByName(mockRecurringRuns[0].display_name)
-            .findKebabActionByMenuId('Duplicate', 'pipeline-recurring-run-actions')
+            .findKebabAction('Duplicate')
             .click();
 
           verifyRelativeURL(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -863,7 +863,7 @@ describe('Pipelines', () => {
     // Check pipeline
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
-      .findKebabActionByMenuId('Delete pipeline', 'pipeline-actions')
+      .findKebabAction('Delete pipeline')
       .click();
     pipelineDeleteModal.shouldBeOpen();
     pipelineDeleteModal.findInput().type(initialMockPipeline.display_name);
@@ -899,7 +899,7 @@ describe('Pipelines', () => {
     pipelineRow.findExpandButton().click();
     pipelineRow
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
-      .findKebabActionByMenuId('Delete pipeline version', 'pipeline-version-actions')
+      .findKebabAction('Delete pipeline version')
       .click();
     pipelineDeleteModal.shouldBeOpen();
     pipelineDeleteModal.findInput().type(initialMockPipelineVersion.display_name);
@@ -1044,7 +1044,7 @@ describe('Pipelines', () => {
     pipelinesTable.find();
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
-      .findKebabActionByMenuId('Create run', 'pipeline-actions')
+      .findKebabAction('Create run')
       .click();
 
     verifyRelativeURL(`/pipelineRuns/${projectName}/runs/create`);
@@ -1088,22 +1088,14 @@ describe('Pipelines', () => {
     // Wait for the pipelines table to load
     pipelinesTable.find();
     const pipelineRow = pipelinesTable.getRowById('argo-workflow');
-    pipelineRow
-      .findKebabActionByMenuId('Create run', 'pipeline-actions')
-      .should('have.attr', 'aria-disabled');
-    pipelineRow
-      .findKebabActionByMenuId('Create schedule', 'pipeline-actions')
-      .should('have.attr', 'aria-disabled');
+    pipelineRow.findKebabAction('Create run').should('have.attr', 'aria-disabled');
+    pipelineRow.findKebabAction('Create schedule').should('have.attr', 'aria-disabled');
 
     pipelineRow.findExpandButton().click();
 
     const pipelineVersionRow = pipelineRow.getPipelineVersionRowById('test-pipeline-version');
-    pipelineVersionRow
-      .findKebabActionByMenuId('Create run', 'pipeline-version-actions')
-      .should('have.attr', 'aria-disabled');
-    pipelineVersionRow
-      .findKebabActionByMenuId('Create schedule', 'pipeline-version-actions')
-      .should('have.attr', 'aria-disabled');
+    pipelineVersionRow.findKebabAction('Create run').should('have.attr', 'aria-disabled');
+    pipelineVersionRow.findKebabAction('Create schedule').should('have.attr', 'aria-disabled');
   });
 
   it('run and schedule dropdown action should be disabeld when pipeline has no versions', () => {
@@ -1112,11 +1104,11 @@ describe('Pipelines', () => {
 
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
-      .findKebabActionByMenuId('Create schedule', 'pipeline-actions')
+      .findKebabAction('Create schedule')
       .should('have.attr', 'aria-disabled');
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
-      .findKebabActionByMenuId('Create run', 'pipeline-actions')
+      .findKebabAction('Create run')
       .should('have.attr', 'aria-disabled');
   });
 
@@ -1127,7 +1119,7 @@ describe('Pipelines', () => {
     pipelinesTable.find();
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
-      .findKebabActionByMenuId('Create schedule', 'pipeline-actions')
+      .findKebabAction('Create schedule')
       .click();
 
     verifyRelativeURL(`/pipelineRuns/${projectName}/schedules/create`);
@@ -1143,7 +1135,7 @@ describe('Pipelines', () => {
     pipelineRow.findExpandButton().click();
     pipelineRow
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
-      .findKebabActionByMenuId('Create run', 'pipeline-version-actions')
+      .findKebabAction('Create run')
       .click();
 
     verifyRelativeURL(`/pipelineRuns/${projectName}/runs/create`);
@@ -1191,7 +1183,7 @@ describe('Pipelines', () => {
     pipelineRow.findExpandButton().click();
     pipelineRow
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
-      .findKebabActionByMenuId('View schedules', 'pipeline-version-actions')
+      .findKebabAction('View schedules')
       .click();
 
     verifyRelativeURL(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/pipelinesList.cy.ts
@@ -149,10 +149,7 @@ describe('PipelinesList', () => {
 
     pipelinesTable.find();
     const pipelineRow = pipelinesTable.getRowById(initialMockPipeline.pipeline_id);
-    pipelineRow
-      .findKebabActionByMenuId('Upload new version', 'pipeline-actions')
-      .should('be.visible')
-      .click();
+    pipelineRow.findKebabAction('Upload new version').should('be.visible').click();
     pipelineVersionImportModal.shouldBeOpen();
   });
 
@@ -166,6 +163,7 @@ describe('PipelinesList', () => {
     pipelineRow
       .getPipelineVersionRowById(initialMockPipelineVersion.pipeline_version_id)
       .findPipelineVersionLink()
+      // TODO - remove force one https://github.com/patternfly/patternfly-react/issues/11314 is fixed
       .click({ force: true });
 
     verifyRelativeURL(
@@ -199,7 +197,7 @@ describe('PipelinesList', () => {
     pipelinesTable.find();
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
-      .findKebabActionByMenuId('Create run', 'pipeline-actions')
+      .findKebabAction('Create run')
       .click();
 
     verifyRelativeURL(`/pipelineRuns/${projectName}/runs/create`);
@@ -212,7 +210,7 @@ describe('PipelinesList', () => {
     pipelinesTable.find();
     pipelinesTable
       .getRowById(initialMockPipeline.pipeline_id)
-      .findKebabActionByMenuId('Create schedule', 'pipeline-actions')
+      .findKebabAction('Create schedule')
       .click();
 
     verifyRelativeURL(`/pipelineRuns/${projectName}/schedules/create`);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/clusterStorage.cy.ts
@@ -174,8 +174,10 @@ describe('ClusterStorage', () => {
     addClusterStorageModal.selectPVSize('MiB');
 
     //connect workbench
-    addClusterStorageModal.findWorkbenchConnectionSelect().click();
-    addClusterStorageModal.findWorkbenchConnectionOption('Test Notebook').click();
+    addClusterStorageModal
+      .findWorkbenchConnectionSelect()
+      .findSelectOption('Test Notebook')
+      .click();
 
     // don't allow duplicate path
     addClusterStorageModal.findMountField().clear();
@@ -275,11 +277,13 @@ describe('ClusterStorage', () => {
 
     clusterStorage.visit('test-project');
     const clusterStorageRow = clusterStorage.getClusterStorageRow('Existing PVC');
-    clusterStorageRow.findKebabActionByMenuId('Edit storage', 'cluster-storage-actions').click();
+    clusterStorageRow.findKebabAction('Edit storage').click();
 
     // Connect to 'Another Notebook'
-    updateClusterStorageModal.findWorkbenchConnectionSelect().click();
-    updateClusterStorageModal.findWorkbenchConnectionOption('Another Notebook').click();
+    updateClusterStorageModal
+      .findWorkbenchConnectionSelect()
+      .findSelectOption('Another Notebook')
+      .click();
 
     updateClusterStorageModal.findMountField().fill('new-data');
 
@@ -338,7 +342,7 @@ describe('ClusterStorage', () => {
     initInterceptors({});
     clusterStorage.visit('test-project');
     const clusterStorageRow = clusterStorage.getClusterStorageRow('Test Storage');
-    clusterStorageRow.findKebabActionByMenuId('Edit storage', 'cluster-storage-actions').click();
+    clusterStorageRow.findKebabAction('Edit storage').click();
     updateClusterStorageModal.findNameInput().should('have.value', 'Test Storage');
     updateClusterStorageModal.findPVSizeInput().should('have.value', '5');
     updateClusterStorageModal.shouldHavePVSizeSelectValue('GiB');
@@ -380,7 +384,7 @@ describe('ClusterStorage', () => {
     initInterceptors({});
     clusterStorage.visit('test-project');
     const clusterStorageRow = clusterStorage.getClusterStorageRow('Unbound storage');
-    clusterStorageRow.findKebabActionByMenuId('Edit storage', 'cluster-storage-actions').click();
+    clusterStorageRow.findKebabAction('Edit storage').click();
     updateClusterStorageModal.findNameInput().should('have.value', 'Unbound storage');
     updateClusterStorageModal.findPVSizeInput().should('have.value', '5').should('be.disabled');
     updateClusterStorageModal.shouldHavePVSizeSelectValue('GiB').should('be.disabled');
@@ -391,7 +395,7 @@ describe('ClusterStorage', () => {
     initInterceptors({});
     clusterStorage.visit('test-project');
     const clusterStorageRow = clusterStorage.getClusterStorageRow('Test Storage');
-    clusterStorageRow.findKebabActionByMenuId('Delete storage', 'cluster-storage-actions').click();
+    clusterStorageRow.findKebabAction('Delete storage').click();
     deleteModal.findInput().fill('Test Storage');
 
     cy.interceptK8s(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/dataConnection.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/dataConnection.cy.ts
@@ -157,9 +157,7 @@ describe('Data connections', () => {
     projectDetails.shouldBeEmptyState('Data connections', 'data-connections', false);
     const dataConnectionRow = projectDetails.getDataConnectionRow('Test Secret');
     dataConnectionRow.findWorkbenchConnection().contains('No connections');
-    dataConnectionRow
-      .findKebabActionByMenuId('Edit data connection', 'data-connection-actions')
-      .click();
+    dataConnectionRow.findKebabAction('Edit data connection').click();
 
     editDataConnectionModal.findNameInput().should('have.value', 'Test Secret');
     editDataConnectionModal.findAwsKeyInput().should('have.value', 'sdsd');
@@ -213,9 +211,7 @@ describe('Data connections', () => {
     initIntercepts({});
     projectDetails.visitSection('test-project', 'data-connections');
     const dataConnectionRow = projectDetails.getDataConnectionRow('Test Secret');
-    dataConnectionRow
-      .findKebabActionByMenuId('Delete data connection', 'data-connection-actions')
-      .click();
+    dataConnectionRow.findKebabAction('Delete data connection').click();
     deleteModal.findInput().type('Test Secret');
     cy.interceptK8s(
       'DELETE',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/permissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/permissions.cy.ts
@@ -138,10 +138,7 @@ describe('Permissions tab', () => {
 
       permissions.visit('test-project');
 
-      userTable
-        .getTableRow('user-1')
-        .findKebabActionByMenuId('Edit', 'role-bindings-permissions-actions')
-        .click();
+      userTable.getTableRow('user-1').findKebabAction('Edit').click();
       userTable.findEditInput('user-1').clear().type('user-3');
       userTable.selectPermission('user-3', 'Admin Edit the project and manage user access');
       userTable.findEditSaveButton('user-3').click();
@@ -171,10 +168,7 @@ describe('Permissions tab', () => {
       ).as('deleteUser');
       permissions.visit('test-project');
 
-      userTable
-        .getTableRow('user-1')
-        .findKebabActionByMenuId('Delete', 'role-bindings-permissions-actions')
-        .click();
+      userTable.getTableRow('user-1').findKebabAction('Delete').click();
 
       cy.wait('@deleteUser');
     });
@@ -238,10 +232,7 @@ describe('Permissions tab', () => {
 
       permissions.visit('test-project');
 
-      groupTable
-        .getTableRow('group-1')
-        .findKebabActionByMenuId('Edit', 'role-bindings-permissions-actions')
-        .click();
+      groupTable.getTableRow('group-1').findKebabAction('Edit').click();
       groupTable.findEditInput('group-1').clear().type('group-3');
       groupTable.selectPermission('group-3', 'Admin Edit the project and manage user access');
       groupTable.findEditSaveButton('group-3').click();
@@ -271,10 +262,7 @@ describe('Permissions tab', () => {
       ).as('deleteGroup');
 
       permissions.visit('test-project');
-      groupTable
-        .getTableRow('group-1')
-        .findKebabActionByMenuId('Delete', 'role-bindings-permissions-actions')
-        .click();
+      groupTable.getTableRow('group-1').findKebabAction('Delete').click();
 
       cy.wait('@deleteGroup');
     });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
@@ -107,16 +107,13 @@ describe('Data science projects details', () => {
     ).as('selfSubjectAccessReviewsCall');
     const deleteProject = projectListPage
       .getProjectRow('Test Project')
-      .findKebabActionByMenuId('Delete project', 'project-actions');
+      .findKebabAction('Delete project');
     cy.wait('@selfSubjectAccessReviewsCall');
     deleteProject.click();
     deleteModal.shouldBeOpen();
     deleteModal.findSubmitButton().should('be.disabled');
     deleteModal.findCancelButton().should('be.enabled').click();
-    projectListPage
-      .getProjectRow('Test Project')
-      .findKebabActionByMenuId('Delete project', 'project-actions')
-      .click();
+    projectListPage.getProjectRow('Test Project').findKebabAction('Delete project').click();
     deleteModal.findInput().type('Test Project');
 
     cy.interceptK8s(
@@ -199,13 +196,13 @@ describe('Data science projects details', () => {
 
     const editProject = projectListPage
       .getProjectRow('Test Project')
-      .findKebabActionByMenuId('Edit project', 'project-actions');
+      .findKebabAction('Edit project');
     const editPermission = projectListPage
       .getProjectRow('Test Project')
-      .findKebabActionByMenuId('Edit permissions', 'project-actions');
+      .findKebabAction('Edit permissions');
     const deleteProject = projectListPage
       .getProjectRow('Test Project')
-      .findKebabActionByMenuId('Delete project', 'project-actions');
+      .findKebabAction('Delete project');
     cy.wait('@selfSubjectAccessReviewsCall');
 
     editProject.should('have.attr', 'aria-disabled', 'true');
@@ -387,15 +384,7 @@ describe('Data science projects details', () => {
 
       // Verify workbench status indicators are not shown
       const projectTableRow = projectListPage.getProjectRow('Test Project');
-      projectTableRow.findNotebookColumnExpander().should('not.exist');
-    });
-
-    it('should not show workbench count or details', () => {
-      projectListPage.visit();
-
-      // Verify no workbench info is shown
-      cy.get('[data-label="Workbenches"]').should('not.exist');
-      cy.get('.pf-v5-c-table__expandable-row-content').should('not.exist');
+      projectTableRow.findNotebookColumn().should('not.exist');
     });
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/workbench.cy.ts
@@ -905,7 +905,7 @@ describe('Workbench page', () => {
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
     notebookRow.shouldHaveNotebookImageName('Test Image');
     notebookRow.shouldHaveContainerSize('Custom');
-    notebookRow.findKebabActionByMenuId('Edit workbench', 'notebook-actions').click();
+    notebookRow.findKebabAction('Edit workbench').click();
     editSpawnerPage.shouldHaveContainerSizeInput('Keep custom size');
     cy.go('back');
     workbenchPage.findCreateButton().click();
@@ -972,7 +972,7 @@ describe('Workbench page', () => {
     );
     workbenchPage.visit('test-project');
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-    notebookRow.findKebabActionByMenuId('Delete workbench', 'notebook-actions').click();
+    notebookRow.findKebabAction('Delete workbench').click();
     deleteModal.findInput().fill('Test Notebook');
     cy.interceptK8s(
       'DELETE',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -114,15 +114,12 @@ describe('Storage classes', () => {
 
       storageClassesTable
         .getRowByConfigName('openshift-default-sc')
-        .findKebabActionByMenuId('Edit', 'storage-class-actions')
+        .findKebabAction('Edit')
         .click();
       storageClassEditModal.findOpenshiftDefaultLabel().should('be.visible');
       storageClassEditModal.findCloseButton().click();
 
-      storageClassesTable
-        .getRowByConfigName('Test SC 1')
-        .findKebabActionByMenuId('Edit', 'storage-class-actions')
-        .click();
+      storageClassesTable.getRowByConfigName('Test SC 1').findKebabAction('Edit').click();
       storageClassEditModal.findOpenshiftScName().should('have.text', 'test-storage-class-1');
       storageClassEditModal.findProvisioner().should('have.text', 'manila.csi.openstack.org');
       storageClassEditModal.findOpenshiftDefaultLabel().should('not.exist');
@@ -165,7 +162,7 @@ describe('Storage classes', () => {
       storageClassTableRow.findLastModifiedValue().should('have.text', '-');
       storageClassTableRow.findEnableValue().should('have.text', '-');
       storageClassTableRow.find().findByTestId('corrupted-metadata-alert').should('be.visible');
-      storageClassTableRow.findKebabActionByMenuId('Edit', 'storage-class-actions').click();
+      storageClassTableRow.findKebabAction('Edit').click();
       storageClassEditModal.findInfoAlert().should('contain.text', 'Reset the metadata');
       storageClassEditModal.fillDisplayNameInput('Readable config');
 

--- a/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
+++ b/frontend/src/__tests__/unit/testUtils/hooks.spec.ts
@@ -52,15 +52,11 @@ describe('hook test utils', () => {
       who: string;
       showCount?: boolean;
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const renderResult = renderHook<any, Props>(
-      ({ who, showCount }: Props) => useSayHello(who, showCount),
-      {
-        initialProps: {
-          who: 'world',
-        },
-      },
-    );
+    const renderResult = renderHook(({ who, showCount }: Props) => useSayHello(who, showCount), {
+      initialProps: {
+        who: 'world',
+      } as Props,
+    });
 
     expect(renderResult).hookToHaveUpdateCount(1);
     expect(renderResult).hookToBe('Hello world!');

--- a/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/experiment/ExperimentTableRow.tsx
@@ -58,7 +58,7 @@ const ExperimentTableRow: React.FC<ExperimentTableRowProps> = ({
         <LastExperimentRuns experiment={experiment} />
       </Td>
       <Td isActionCell dataLabel="Kebab">
-        <ActionsColumn id="experiment-actions" items={actionColumnItems} />
+        <ActionsColumn items={actionColumnItems} />
       </Td>
     </Tr>
   );

--- a/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipeline/PipelinesTableRow.tsx
@@ -117,7 +117,6 @@ const PipelinesTableRow: React.FC<PipelinesTableRowProps> = ({
           <Td>{loading ? <Skeleton /> : <PipelinesTableRowTime date={updatedDate} />}</Td>
           <Td isActionCell>
             <ActionsColumn
-              id="pipeline-actions"
               items={[
                 {
                   title: 'Upload new version',

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
@@ -104,7 +104,6 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
       </Td>
       <Td isActionCell dataLabel="Kebab">
         <ActionsColumn
-          id="pipeline-recurring-run-actions"
           items={[
             ...(!version
               ? []

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -174,7 +174,6 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
       {hasRowActions && (
         <Td isActionCell dataLabel="Kebab">
           <ActionsColumn
-            id="pipeline-run-table-row-actions"
             data-testid="pipeline-run-table-row-actions"
             items={actions}
             popperProps={{ appendTo: getDashboardMainContainer, position: 'right' }}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineVersion/PipelineVersionTableRow.tsx
@@ -86,7 +86,6 @@ const PipelineVersionTableRow: React.FC<PipelineVersionTableRowProps> = ({
       </Td>
       <Td isActionCell>
         <ActionsColumn
-          id="pipeline-version-actions"
           items={[
             {
               title: 'Create run',

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRow.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsTableRow.tsx
@@ -191,7 +191,6 @@ const RoleBindingPermissionsTableRow: React.FC<RoleBindingPermissionsTableRowPro
             </Tooltip>
           ) : (
             <ActionsColumn
-              id="role-bindings-permissions-actions"
               items={[
                 {
                   title: 'Edit',

--- a/frontend/src/pages/BYONImages/BYONImagesTableRow.tsx
+++ b/frontend/src/pages/BYONImages/BYONImagesTableRow.tsx
@@ -91,7 +91,6 @@ const BYONImagesTableRow: React.FC<BYONImagesTableRowProps> = ({
         </Td>
         <Td isActionCell>
           <ActionsColumn
-            id="byon-image-actions"
             items={[
               {
                 title: 'Edit',

--- a/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTableRow.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/list/AcceleratorProfilesTableRow.tsx
@@ -61,7 +61,6 @@ const AcceleratorProfilesTableRow: React.FC<AcceleratorProfilesTableRowType> = (
       </Td>
       <Td isActionCell>
         <ActionsColumn
-          id="accelerator-profile-actions"
           items={[
             {
               title: 'Edit',

--- a/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationRow.tsx
+++ b/frontend/src/pages/acceleratorProfiles/screens/manage/tolerations/TolerationRow.tsx
@@ -22,7 +22,6 @@ const TolerationRow: React.FC<TolerationRowProps> = ({ toleration, onEdit, onDel
       <Td dataLabel="Toleration Seconds">{formatSeconds(toleration.tolerationSeconds)}</Td>
       <Td isActionCell>
         <ActionsColumn
-          id="toleration-actions"
           items={[
             {
               title: 'Edit',

--- a/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/ConnectionTypesTableRow.tsx
@@ -142,7 +142,6 @@ const ConnectionTypesTableRow: React.FC<ConnectionTypesTableRowProps> = ({
       </Td>
       <Td className="odh-project-table__action-column" isActionCell>
         <ActionsColumn
-          id="connection-type-actions"
           items={[
             {
               title: 'Preview',

--- a/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
+++ b/frontend/src/pages/connectionTypes/manage/ManageConnectionTypeFieldsTableRow.tsx
@@ -179,7 +179,6 @@ const ManageConnectionTypeFieldsTableRow: React.FC<Props> = ({
       </Td>
       <Td isActionCell>
         <ActionsColumn
-          id="connection-type-field-actions"
           items={[
             {
               title: 'Edit',

--- a/frontend/src/pages/modelRegistry/screens/ModelPropertiesTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelPropertiesTableRow.tsx
@@ -175,7 +175,6 @@ const ModelPropertiesTableRow: React.FC<ModelPropertiesTableRowProps> = ({
             </ActionList>
           ) : (
             <ActionsColumn
-              id="model-properties-actions"
               isDisabled={isSavingEdits}
               popperProps={{ direction: 'up' }}
               items={[

--- a/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -107,7 +107,7 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
       </Td>
       {!isArchiveModel && (
         <Td isActionCell>
-          <ActionsColumn id="model-version-actions" items={actions} />
+          <ActionsColumn items={actions} />
           {isArchiveModalOpen ? (
             <ArchiveModelVersionModal
               onCancel={() => setIsArchiveModalOpen(false)}

--- a/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisteredModels/RegisteredModelTableRow.tsx
@@ -105,7 +105,7 @@ const RegisteredModelTableRow: React.FC<RegisteredModelTableRowProps> = ({
         </Content>
       </Td>
       <Td isActionCell>
-        <ActionsColumn id="registered-modal-actions" items={actions} />
+        <ActionsColumn items={actions} />
         {isArchiveModalOpen ? (
           <ArchiveRegisteredModelModal
             onCancel={() => setIsArchiveModalOpen(false)}

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistriesTableRow.tsx
@@ -63,7 +63,6 @@ const ModelRegistriesTableRow: React.FC<ModelRegistriesTableRowProps> = ({
         </Td>
         <Td isActionCell>
           <ActionsColumn
-            id="model-registry-actions"
             items={[
               {
                 title: 'View database configuration',

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -59,7 +59,6 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
       </Td>
       <Td isActionCell>
         <ActionsColumn
-          id="custom-serving-runtime-actions"
           items={
             templateOOTB
               ? [

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -106,7 +106,6 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
         <Td dataLabel="Kebab" isActionCell>
           <ResourceActionsColumn
             resource={inferenceService}
-            id="inference-table-actions"
             items={[
               {
                 title: 'Edit',

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
@@ -190,7 +190,6 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
         </Td>
         <Td isActionCell>
           <ActionsColumn
-            id="serving-runtime-actions"
             items={[
               {
                 title: 'Edit model server',

--- a/frontend/src/pages/notebookController/screens/admin/NotebookActions.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookActions.tsx
@@ -23,7 +23,7 @@ const NotebookActions: React.FC<ServerStatusProps> = ({ data }) => {
     },
   ];
 
-  return <ActionsColumn id="notebook-actions" items={rowActions} />;
+  return <ActionsColumn items={rowActions} />;
 };
 
 export default NotebookActions;

--- a/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/data-connections/DataConnectionsTableRow.tsx
@@ -43,7 +43,6 @@ const DataConnectionsTableRow: React.FC<DataConnectionsTableRowProps> = ({
     </Td>
     <Td isActionCell>
       <ActionsColumn
-        id="data-connection-actions"
         items={[
           {
             title: 'Edit data connection',

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -175,7 +175,7 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
           </Td>
         )}
         <Td isActionCell>
-          <ActionsColumn id="cluster-storage-actions" items={actions} />
+          <ActionsColumn items={actions} />
         </Td>
       </Tr>
       <Tr isExpanded={isExpanded}>

--- a/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
+++ b/frontend/src/pages/projects/screens/projects/ProjectTableRow.tsx
@@ -129,7 +129,7 @@ const ProjectTableRow: React.FC<ProjectTableRowProps> = ({
           onMouseEnter={runAccessCheck}
           onClick={runAccessCheck}
         >
-          <ActionsColumn id="project-actions" items={item} />
+          <ActionsColumn items={item} />
         </Td>
       </Tr>
       {expandColumn ? (

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -296,7 +296,6 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({ 
           )}
 
           <ActionsColumn
-            id="storage-class-actions"
             items={[
               {
                 title: 'Edit',


### PR DESCRIPTION
- Removes `findKebabActionByMenuId`
- Removes `id` attributes which were added to `ActionsColumn`
- Fixes a few selectors that were manually searching for dropdown / select menus at the root and instead now use the functions available from `application.ts`
- Replace some instances of `cy.get`